### PR TITLE
本番環境をリトルサーバへ移行完了

### DIFF
--- a/dnsconfig.js
+++ b/dnsconfig.js
@@ -11,11 +11,9 @@ DEFAULTS(
 );
 
 D("actlab.org", REG_NONE, DnsProvider(DNS_CLOUDFLARE),
-    A("@", "160.251.151.230"),
-    A("autoconfig", "160.251.151.230"),
-    A("www", "160.251.151.230"),
-	TXT("_acme-challenge", "vdyI3egeYp_4xplZ1DBXKVk0XMH_aG6ycbxuREuvAjY"),
-	TXT("_acme-challenge.www", "I5W9BuLmAUoYyovdarNYEM3QRCvNmqp-6y7cS9ktZLs"),
+    A("@", "113.36.242.231"),
+    A("autoconfig", "113.36.242.231"),
+    A("www", "113.36.242.231"),
 
     A("lamp", "160.16.58.123"),
     A("www.lamp", "160.16.58.123"),


### PR DESCRIPTION
本番環境を書き換えます。
Aレコードをcv2.lsv.jpに向けます。

あわせて、移行用に一時的に必要となっていた証明書発行用のtxtレコードを削除します。